### PR TITLE
Add test scaffolding for wave 1

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -5,9 +5,8 @@ Congratulations! You're submitting your assignment.
 
 Feature | Feedback
 --- | ---
-How do you feel you and your partner did in sharing responsibilities? | 
-Why do you think we chose to make the `score` method in the `Scoring` class a **class method** instead of an **instance method**? | 
-Describe an example of a test you wrote for a _nominal case_. | 
+How do you feel you and your partner did in sharing responsibilities? |
+Why do you think we chose to make the `score` method in the `Scoring` class a **class method** instead of an **instance method**? |
+Describe an example of a test you wrote for a _nominal case_. |
 Describe an example of a test you wrote for an _edge case_. | 
-What was your final test coverage percentage? | 
-Is there a specific piece of code you'd like feedback on? | 
+Is there a specific piece of code you'd like feedback on? |

--- a/README.md
+++ b/README.md
@@ -1,32 +1,39 @@
 # Scrabble
 
+## At a Glance
+
+- Practice TDD and organizing complex code by building some of the logic for a Scrabble game
+- [Stage 2](https://github.com/Ada-Developers-Academy/pedagogy/blob/master/rule-of-three.md) pair project
+- Due **DATE HERE**
+
+## Introduction
+
 Our project manager just informed us of our next large project: we need to make the foundation code for a game of Scrabble.
 
 Use __Test Driven Development (TDD)__ to create a collection of Ruby classes that would provide the foundation for creating a Scrabble game.  **In this project we will NOT create a full Scrabble game.** Another team of developers will create the program that runs a Scrabble game and finish the game logic.
 
 ### Learning Goals
 - Use __Test Driven Development (TDD)__ to write tests and code in parallel
-- Create class and instance methods according to requirements
+- Create classes methods according to requirements
 - Utilize [Single Responsibility Principle](https://en.wikipedia.org/wiki/Single_responsibility_principle) to reduce code dependencies
-- Utilize composition between classes, where appropriate
+- Utilize composition between classes
 
 ## Getting Started
-This is [Stage 2](https://github.com/Ada-Developers-Academy/pedagogy/blob/master/rule-of-three.md) pair project.
 
-From the project root, you should be able to execute all of your specs by running `rake`. Each Ruby class should be in its own file in `lib/`, and the entire project should be in a `module` called `Scrabble`. You will need to use `require`, `require_relative`, `include` and/or `extend` to tell Ruby how to work with classes in multiple files.
+From the project root, you should be able to execute all of your specs by running `rake`. Each Ruby class should be in its own file in `lib/`, and the entire project should be in a `module` called `Scrabble`. You will need to use `require_relative` to tell Ruby how to work with classes in multiple files.
 
 ### Tests
 We will use [minitest](https://github.com/seattlerb/minitest) for this project. This is the same test framework that we've used for your previous project. Your spec descriptions should be meaningful and organized into `describe` blocks that reflect your intent on how to use the code.
 
-To set up tests for your project, you will need to create a `Rakefile` and a `specs` directory. Use a Rakefile from an older project to create this Rakefile.
+We have provided you with a `Rakefile` and some spec files to get you started.
 
 Do not move onto a new tier of requirements until the minimum requirements of the previous tier are complete and your specs are green across the board. Use __TDD__ to drive your development and document your edge cases.
 
-### What We Provide
-We have provided some boilerplate code for your Scrabble game, in `wave-1-game.rb`, `wave-2-game.rb`, and `wave-3-game.rb`. Running `$ ruby wave-1-game.rb` will begin a command-line game that uses your Scrabble code. The boilerplate code will break the first time you run it: working through the waves specified below should create a running version of the game. **Implementing code to make this game run is not a substitute for TDD or writing tests**. It is simply there for you and your pair to reference how the Game may run during each wave, to have better perspective of what your program can do, and to have exposure to legacy code. We fully expect you to create the specified classes below strictly through TDD.
+### Driver Code
+We have provided some driver code for your Scrabble game in the files `wave-1-game.rb`, `wave-2-game.rb`, and `wave-3-game.rb`. Running `$ ruby wave-1-game.rb` will begin a command-line game that uses your Scrabble code. The boilerplate code will break the first time you run it: working through the waves specified below should create a running version of the game. **Implementing code to make this game run is not a substitute for TDD or writing tests**. It is simply there for you and your pair to reference how the Game may run during each wave, to have better perspective of what your program can do, and to get some practice reading other peoples' code. We fully expect you to create the specified classes below strictly through TDD.
 
 ### Pair Programming
-Utilize good pair programming practices. Refer to articles from the [Agile Alliance](http://guide.agilealliance.org/guide/pairing.html) and the [Agile Institute](http://powersoftwo.agileinstitute.com/2015/02/benefits-of-pair-programming-revisited.html) if you need a refresher for some best practices. Switch _driver_ and _navigator_ roles often. When there is uncertainity or confusion, step away from the keyboard and discuss, plan, and document on paper or whiteboard before continuing.
+Utilize good pair programming practices. Refer to articles from the [Agile Alliance](http://guide.agilealliance.org/guide/pairing.html) and the [Agile Institute](http://powersoftwo.agileinstitute.com/2015/02/benefits-of-pair-programming-revisited.html) if you need a refresher for some best practices. Switch _driver_ and _navigator_ roles often. When there is uncertainty or confusion, step away from the keyboard and discuss, plan, and document on paper or whiteboard before continuing.
 
 ## Baseline
 ### Setup
@@ -42,10 +49,12 @@ Utilize good pair programming practices. Refer to articles from the [Agile Allia
 First, come up with a "plan of action" for how you want to work as a pair. Discuss your learning style, how you prefer to receive feedback, and one team communication skill you want to improve with this experience. Second, review the requirements for Wave 1 and come up with a "plan of action" for your implementation.
 
 #### Implementation
-- Create a `Scrabble` module at the project root.
-- Create a `Scrabble::Scoring` **class** which contains some sort of data structure to store the **individual letter scores** listed below.
-- Create a Spec file which corresponds to your `Scrabble::Scoring` class. This spec should contain one __red__ test as a starting point (this test can be modified as your get further through the requirements).
-- Be able to execute your one test using `rake` from the project root.
+- Read through the file `lib/scoring.rb`. Inside this file, you should find:
+    - A `Scrabble` module
+    - A `Scrabble::Scoring` **class**
+- Add some sort of data structure to `Scrabble::Scoring` to store the **individual letter scores** listed below
+- Read through the spec file `specs/scoring_spec.rb`, which corresponds to your `Scrabble::Scoring` class. This file has some tests pre-written and some test stubs that you will need to fill in.
+- Be able to execute the tests using `rake` from the project root.
 
 #### Score chart
 |Letter                        | Value|
@@ -60,33 +69,46 @@ First, come up with a "plan of action" for how you want to work as a pair. Discu
 
 ## Wave 1
 ### Primary Requirements
-Create a `Scrabble::Scoring` class with __full unit testing/specs__. You should have a spec that tests all pieces of functionality and logic. The class should have the following **class methods**:
+For wave 1 you are given some scaffolding: tests and test stubs in `specs/scoring_spec.rb`, and method stubs in `lib/scoring.rb`.
+
+Complete the `Scrabble::Scoring` class with __full unit testing/specs__. All provided tests should pass, and all stubbed tests should be fully implemented (and pass). The class should have the following **class methods**:
 
 - `self.score(word)`: returns the total score for the given word. The word is input as a string (case insensitive). The chart in the baseline requirements shows the point value for a given letter.
-  - A seven letter word means that a player used all the tiles. Seven letter words receive a __50__ point bonus.
-- `self.highest_score_from_array(array_of_words)`: returns **the word in the array with the highest score**. In the case of tie, use these tiebreaking rules:
+    - A seven letter word means that a player used all the tiles. Seven letter words receive a __50__ point bonus.
+    - Tests for `Scoring.score` are _already written_. Your job is to write code to make them pass.
+- `self.highest_score_from(array_of_words)`: returns **the word in the array with the highest score**. In the case of tie, use these tie-breaking rules:
     - It’s better to use fewer tiles, in the case of a tie, prefer the word with the fewest letters.
     - There is a bonus for words that are seven letters. If the top score is tied between multiple words and one used all seven letters, choose the one with seven letters over the one with fewer tiles.
     - If the there are multiple words that are the same score and same length, pick the first one in the supplied list.
+    - Tests for this logic are _stubbed_, meaning the test has a name but no code written. You will have to implement them as you work on this method.
 
 ## Wave 2
 ### Primary Requirements
-Create a `Scrabble::Player` class with __full unit testing/specs__. You should have a spec that tests all pieces of functionality and logic. The only required parameter for instances of the class is the player's `name`. Instances of the class should repond to the following messages (note, this does not necessarily mean that each of these need to be written as _new methods_):
+For waves 2 and 3, you are given no starter code. You and your pair will have to create all files and classes and write all the tests yourselves.
+
+Create a `Scrabble::Player` class with __full unit testing/specs__. You should have a spec that tests all pieces of functionality and logic.
+
+The constructor for `Scrabble::Player` should take exactly one argument: the player's `name`. Instances of the class should respond to the following messages:
 
 - `#name`: returns the value of the `@name` instance variable
 - `#plays`: returns an Array of the words played by the player
 - `#play(word)`: Adds the input word to the `plays` Array
     - Returns `false` if player has already won
-    - Returns the score of the `word`
+    - Otherwise returns the score of the `word`
 - `#total_score`: Returns the sum of scores of played words
 - `#won?`: If the player has over 100 points, returns `true`, otherwise returns `false`
 - `#highest_scoring_word`: Returns the highest scoring played word
 - `#highest_word_score`: Returns the `highest_scoring_word` score
 
 For example,
+
 ```ruby
 player = Scrabble::Player.new("Ada")
-player.name #=> "Ada"
+player.name           # => "Ada"
+player.play('cat')    # => 5
+player.play('lizard') # => 16
+puts player.highest_scoring_word
+# prints out "lizard"
 ```
 
 ## Wave 3
@@ -123,6 +145,7 @@ Create specs for and add to the `Player` class the following instance methods:
     - It is not in the primary requirements to modify the existing `#play(word)` to use `#tiles` or check against the player's tiles
 
 ### Optional Enhancements
+These need to be tested too!
 - Modify in `Player` the `#play(word)` method to only allow the player to play words using letters that the player has tiles for.
 - Create a `Scrabble::Dictionary` class that includes a method (class or instance) for searching a list of words to determine if a given word is valid (__must have tests__).
 - Create a `Scrabble::Board` class (__must have tests__) that has a matrix (array of arrays) of tile places. Check if a word can be played on a given tile place in a certain direction (up/down or left/right).

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,9 @@
+require 'rake/testtask'
+
+Rake::TestTask.new do |t|
+  t.libs = ["lib"]
+  t.warning = true
+  t.test_files = FileList['specs/*_spec.rb']
+end
+
+task default: :test

--- a/feedback.md
+++ b/feedback.md
@@ -3,25 +3,24 @@
 
 Feature | Feedback
 --- | ---
-**General** | 
-Answered comprehension questions | 
-Both Teammates contributed to the codebase | 
-Regular Commits with meaningful commit messages | 
-**Scoring class** | 
-`score` method | 
-Uses appropriate data structure to store the letter score | 
-Appropriately handles edge cases | 
-Tests `score` edge cases (one-letter word, 7 letter word) | 
-`highest_scoring_word` method | 
-Appropriately handles edge cases | 
-Tests `highest_scoring_word` edge cases (ties, no words, no array) | 
-**Player class** | 
-Uses an array to keep track of words played | 
-Uses existing code to create `highest_scoring_word` and `highest_word_score` | 
-Returns `true` or `false` from `won?` method | 
-Tests edge cases on the `play(word)` method for words that cannot be scored | 
-**TileBag class** | 
-Uses a data structure to keep the set of default tiles in the bag | 
-`draw_tiles` method uses the parameter to draw a set of random tiles | 
-`tiles_remaining` method returns a count | 
-Tests `draw_tiles` edge cases for different parameter inputs | 
+**General** |
+Answered comprehension questions |
+Both Teammates contributed to the codebase |
+Regular Commits with meaningful commit messages |
+**Scoring class** |
+`score` method |
+Uses appropriate data structure to store the letter score |
+Appropriately handles edge cases |
+`highest_score_from` method |
+Appropriately handles edge cases |
+Test implementations for `highest_score_from`|
+**Player class** |
+Uses an array to keep track of words played |
+Uses existing code to create `highest_scoring_word` and `highest_word_score` |
+Returns `true` or `false` from `won?` method |
+Tests edge cases on the `play(word)` |
+**TileBag class** |
+Uses a data structure to keep the set of default tiles in the bag |
+`draw_tiles` method uses the parameter to draw a set of random tiles |
+`tiles_remaining` method returns a count |
+Tests `draw_tiles` edge cases |

--- a/lib/scoring.rb
+++ b/lib/scoring.rb
@@ -1,6 +1,6 @@
 module Scrabble
   class Scoring
-    def self.score
+    def self.score(word)
     end
 
     def self.highest_score_from(array_of_words)

--- a/lib/scoring.rb
+++ b/lib/scoring.rb
@@ -1,0 +1,9 @@
+module Scrabble
+  class Scoring
+    def self.score
+    end
+
+    def self.highest_score_from(array_of_words)
+    end
+  end
+end

--- a/specs/scoring_spec.rb
+++ b/specs/scoring_spec.rb
@@ -8,5 +8,55 @@ require_relative '../lib/scoring'
 Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new
 
 describe 'Scoring' do
-  
+  describe 'score' do
+    it 'correctly scores simple words' do
+      Scrabble::Scoring.score('dog').must_equal 5
+      Scrabble::Scoring.score('cat').must_equal 5
+      Scrabble::Scoring.score('pig').must_equal 6
+    end
+
+    it 'adds 50 points for a 7-letter word' do
+      Scrabble::Scoring.score('academy').must_equal 65
+    end
+
+    it 'handles all upper- and lower-case letters' do
+      Scrabble::Scoring.score('dog').must_equal 5
+      Scrabble::Scoring.score('DOG').must_equal 5
+      Scrabble::Scoring.score('DoG').must_equal 5
+    end
+
+    it 'returns nil for strings containing bad characters' do
+      Scrabble::Scoring.score('#$%^').must_be_nil
+      Scrabble::Scoring.score('char^').must_be_nil
+      Scrabble::Scoring.score(' ').must_be_nil
+    end
+
+    it 'returns nil for words > 7 letters' do
+      Scrabble::Scoring.score('abcdefgh').must_be_nil
+    end
+
+    it 'returns nil for empty words' do
+      Scrabble::Scoring.score('').must_be_nil
+    end
+  end
+
+  describe 'highest_score_from' do
+    it 'returns nil if no words were passed' do
+    end
+
+    it 'returns the only word in a length-1 array' do
+    end
+
+    it 'returns the highest word if there are two words' do
+    end
+
+    it 'if tied, prefer a word with 7 letters' do
+    end
+
+    it 'if tied and no word has 7 letters, prefers the word with fewer letters' do
+    end
+
+    it 'returns the first word of a tie with same letter count' do
+    end
+  end
 end

--- a/specs/scoring_spec.rb
+++ b/specs/scoring_spec.rb
@@ -1,0 +1,12 @@
+require 'minitest/autorun'
+require 'minitest/reporters'
+require 'minitest/skip_dsl'
+
+require_relative '../lib/scoring'
+
+# Get that nice colorized output
+Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new
+
+describe 'Scoring' do
+  
+end


### PR DESCRIPTION
As discussed on Friday afternoon.

Tests are borrowed from https://github.com/AdaGold/js-scrabble/blob/master/spec/scrabble_spec.js

Implementation I used to verify the tests is at https://gist.github.com/droberts-ada/6b9f4e4790eec0978b13f057423f1a5f

I went through and updated the README, PR template and feedback table to match. I also cleaned up / clarified some small things and fixed some spelling errors.